### PR TITLE
Add multi-topic hour-long audio option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,5 +53,16 @@ This copies the file to `approved/`, splits the text into chunks and calls
 the ElevenLabs API to generate individual audio files. Finally all parts are
 merged into a single mp3 placed in the `output/` directory.
 
+### Process multiple topics
+
+```bash
+python auto_tts.py --topics topics.txt [--basename NAME]
+```
+
+`topics.txt` must contain one topic per line. You can also provide a
+comma-separated list directly. For each topic the script generates a segment so
+that the total length is roughly one hour of narration. All generated audio
+parts are merged into a single mp3 under `output/`.
+
 Run `python auto_tts.py -h` to see all available options.
 


### PR DESCRIPTION
## Summary
- support `--topics` to process multiple topics in one run
- compute per-topic character target so combined audio is about an hour
- merge all audio segments into one file
- document multi-topic usage in README

## Testing
- `python -m py_compile auto_tts.py`
- `python test_template.py`

------
https://chatgpt.com/codex/tasks/task_e_6888d0f59c0c832a92f0276c344c09f0