### PR TITLE
Add Wikimedia image search helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,21 @@ parts are merged into a single mp3 under `output/`.
 
 Run `python auto_tts.py -h` to see all available options.
 
+## Searching for images
+
+The helper function `search_wikimedia_images()` can fetch freely licensed
+images from Wikimedia Commons for a given topic.
+
+```python
+from auto_tts import search_wikimedia_images
+
+images = search_wikimedia_images("Sea Bishop", limit=2)
+for img in images:
+    print(img["url"])
+```
+
+Use this to collect illustrative material for each script segment.
+
 
 ## GUI Usage
 


### PR DESCRIPTION
## Summary
- add `search_wikimedia_images()` in `auto_tts.py` for pulling freely licensed images
- document the helper in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68894655e7c0832aa2e9ed5390197f8b