### PR TITLE
Improve download error handling

### DIFF
--- a/auto_tts.py
+++ b/auto_tts.py
@@ -110,8 +110,12 @@ def search_wikimedia_images(query: str, limit: int = 3) -> List[dict]:
         "iiprop": "url|extmetadata",
     }
 
-    r = requests.get(api, params=params, timeout=15)
-    r.raise_for_status()
+    try:
+        r = requests.get(api, params=params, timeout=15)
+        r.raise_for_status()
+    except requests.RequestException as e:
+        print(f"❌ Wikimedia request failed: {e}")
+        return []
     data = r.json()
 
     results = []
@@ -140,12 +144,14 @@ def tts_chunk(text: str, idx: int, basename: str) -> Path:
         "model_id": "eleven_multilingual_v2",
         "voice_settings": {"stability": 0.45, "similarity_boost": 0.8, "speed": 1.0}
     }
-    r = requests.post(url, headers=headers, json=payload, timeout=180)
     try:
+        r = requests.post(url, headers=headers, json=payload, timeout=180)
         r.raise_for_status()
-    except Exception:
+    except requests.RequestException as e:
         print("❌ ElevenLabs Fehlerantwort:")
-        print(r.text[:500])
+        if 'r' in locals():
+            print(r.text[:500])
+        print(e)
         raise
 
     fn = PARTS_DIR / f"{basename}_{idx:02d}.mp3"

--- a/auto_tts_gui.py
+++ b/auto_tts_gui.py
@@ -76,11 +76,22 @@ def select_images(topic: str, limit: int = 5):
     saved = []
 
     for idx, img in enumerate(images, 1):
-        try:
-            r = requests.get(img["url"], timeout=15)
-            r.raise_for_status()
-        except Exception:
-            print(f"Failed to download {img['url']}")
+        r = None
+        while True:
+            try:
+                r = requests.get(img["url"], timeout=15)
+                r.raise_for_status()
+                break
+            except requests.RequestException as e:
+                print(f"Failed to download {img['url']}: {e}")
+                choice = input("Retry download? [y/N]: ").strip().lower()
+                if choice == "y":
+                    continue
+                break
+            except Exception as e:
+                print(f"Unexpected error downloading {img['url']}: {e}")
+                break
+        if r is None:
             continue
 
         keep = False


### PR DESCRIPTION
## Summary
- handle Wikimedia errors explicitly
- give more detail when ElevenLabs requests fail
- ask whether to retry image downloads

## Testing
- `python -m py_compile auto_tts.py auto_tts_gui.py test_template.py`
- `pip install -r requirements.txt`
- `python test_template.py`

------
https://chatgpt.com/codex/tasks/task_e_688954a9ac30832aa0d0d93316282868