### PR TITLE
Add image approval test mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,11 @@ approved a final mp3 is created combining all pieces.
 ```bash
 python auto_tts_gui.py
 ```
+
+To test just the image search and approval workflow without running the
+full pipeline, use the `--test-images` option. Provide a topic with
+`--topic` (defaults to "Sperm Whale vs Colossal Squid"):
+
+```bash
+python auto_tts_gui.py --test-images --topic "Sea Bishop"
+```

--- a/auto_tts_gui.py
+++ b/auto_tts_gui.py
@@ -172,4 +172,23 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Run the GUI workflow")
+    ap.add_argument(
+        "--test-images",
+        action="store_true",
+        help="Only run image approval for --topic and exit",
+    )
+    ap.add_argument(
+        "--topic",
+        default="Sperm Whale vs Colossal Squid",
+        help="Topic to search images for in --test-images mode",
+    )
+    args = ap.parse_args()
+
+    if args.test_images:
+        chosen = select_images(args.topic)
+        print(f"Saved {len(chosen)} image(s)")
+    else:
+        main()


### PR DESCRIPTION
## Summary
- extend `auto_tts_gui.py` with `--test-images` option
- document how to run the new image search test

## Testing
- `python -m py_compile auto_tts_gui.py auto_tts.py test_template.py`
- `OPENAI_API_KEY=a ELEVEN_API_KEY=b python auto_tts_gui.py --test-images --topic "Sea Bishop"` *(fails to fetch images due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688a5545b03c832a8ab7edf105feec30