### PR TITLE
Add User-Agent header for Wikimedia requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,16 @@ full pipeline, use the `--test-images` option. Provide a topic with
 ```bash
 python auto_tts_gui.py --test-images --topic "Sea Bishop"
 ```
+
+### Wikimedia User-Agent
+
+Wikimedia requires a descriptive `User-Agent` header for API and file requests.
+Set the environment variable `USER_AGENT` to something that identifies your
+application, for example:
+
+```bash
+export USER_AGENT="yt_auto_tts/1.0 (contact: you@example.com)"
+```
+
+The helper functions automatically include this header when querying and
+downloading images.

--- a/auto_tts.py
+++ b/auto_tts.py
@@ -32,6 +32,7 @@ GPT_MODEL  = os.getenv("GPT_MODEL", "gpt-4o")
 
 # average characters spoken per minute; used for multi-topic mode
 CHARS_PER_MIN = 700
+USER_AGENT = os.getenv("USER_AGENT", "yt_auto_tts/1.0 (+https://example.com)")
 
 if not OPENAI_KEY or not ELEVEN_KEY:
     raise SystemExit("❌ OPENAI_API_KEY oder ELEVEN_API_KEY fehlt in .env")
@@ -110,8 +111,9 @@ def search_wikimedia_images(query: str, limit: int = 3) -> List[dict]:
         "iiprop": "url|extmetadata",
     }
 
+    headers = {"User-Agent": USER_AGENT}
     try:
-        r = requests.get(api, params=params, timeout=15)
+        r = requests.get(api, params=params, headers=headers, timeout=15)
         r.raise_for_status()
     except requests.RequestException as e:
         print(f"❌ Wikimedia request failed: {e}")

--- a/auto_tts_gui.py
+++ b/auto_tts_gui.py
@@ -18,6 +18,7 @@ from auto_tts import (
     search_wikimedia_images,
     slugify,
     IMAGES_DIR,
+    USER_AGENT,
 )
 
 
@@ -77,9 +78,10 @@ def select_images(topic: str, limit: int = 5):
 
     for idx, img in enumerate(images, 1):
         r = None
+        headers = {"User-Agent": USER_AGENT}
         while True:
             try:
-                r = requests.get(img["url"], timeout=15)
+                r = requests.get(img["url"], headers=headers, timeout=15)
                 r.raise_for_status()
                 break
             except requests.RequestException as e:
@@ -107,7 +109,12 @@ def select_images(topic: str, limit: int = 5):
         win = tk.Tk()
         win.title(f"{topic} ({idx}/{len(images)})")
         bio = BytesIO(r.content)
-        pil_img = Image.open(bio)
+        try:
+            pil_img = Image.open(bio)
+        except Exception:
+            print(f"Skipping invalid image: {img['url']}")
+            win.destroy()
+            continue
         pil_img.thumbnail((500, 500))
         tk_img = ImageTk.PhotoImage(pil_img)
         lbl = tk.Label(win, image=tk_img)


### PR DESCRIPTION
## Summary
- set configurable USER_AGENT constant
- include User-Agent header when fetching images
- skip invalid images in GUI workflow
- document USER_AGENT environment variable

## Testing
- `python -m py_compile auto_tts.py auto_tts_gui.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688a71a22284832ab943f3a736c7dd73