### PR TITLE
Enhance Wikimedia search

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,13 @@ Run `python auto_tts.py -h` to see all available options.
 ## Searching for images
 
 The helper function `search_wikimedia_images()` can fetch freely licensed
-images from Wikimedia Commons for a given topic.
+images from Wikimedia Commons. You can provide a single search term or a list
+of alternative queries.
 
 ```python
 from auto_tts import search_wikimedia_images
 
-images = search_wikimedia_images("Sea Bishop", limit=2)
+images = search_wikimedia_images(["Sea Bishop", "sea monster"], limit=2)
 for img in images:
     print(img["url"])
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ openai
 requests
 pydub
 Pillow
+nltk
 


### PR DESCRIPTION
## Summary
- support multiple search terms in `search_wikimedia_images`
- include automatic synonym lookup in the GUI
- gather up to 20 images using all available terms
- note new ability in the README
- add nltk to requirements

## Testing
- `python test_template.py`

------
https://chatgpt.com/codex/tasks/task_e_688b7828ea04832ab2ea6b852f39d78c