### PR TITLE
Add Unsplash image search helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ for img in images:
 
 Use this to collect illustrative material for each script segment.
 
+If you provide an ``UNSPLASH_ACCESS_KEY`` in your environment you can also
+use ``search_unsplash_images()``. The convenience helper ``search_images_for_script()``
+creates simple search queries from a script and combines results from both
+sources so you can easily fill an entire story with background images.
+
 
 ## GUI Usage
 


### PR DESCRIPTION
## Summary
- add `search_unsplash_images` and helpers to create queries from a script
- add `search_images_for_script` convenience function
- update documentation for the new image search workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cae27f35c832a89b9b8ec003c9be9